### PR TITLE
Adds SS6 support

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -7,3 +7,7 @@ SilverStripe\Core\Injector\Injector:
     class: Innoweb\PrefixRequirements\Control\PrefixResourceURLGenerator
     properties:
       nonceStyle: mtime
+
+Innoweb\PrefixRequirements\Control\PrefixResourceURLGenerator:
+  excluded_resources:
+    - 'themes/startup-theme/css/startup.css'

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require":
 	{
 		"silverstripe/framework": "^5",
-		"webmozart/glob": "^4.6.0"
+		"webmozart/glob": "^4.7.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
 	}],
 	"require":
 	{
-		"silverstripe/framework": "^5",
-		"webmozart/glob": "^4.7.0"
+		"silverstripe/framework": "^5 || ^6",
+		"webmozart/glob": "^4.6.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Control/PrefixResourceURLGenerator.php
+++ b/src/Control/PrefixResourceURLGenerator.php
@@ -74,7 +74,8 @@ class PrefixResourceURLGenerator extends SimpleResourceURLGenerator implements R
 
     public function urlForResource($relativePath)
     {
-        if (!Controller::has_curr() || is_a(Controller::curr(), LeftAndMain::class)) {
+        $curr = Controller::curr();
+        if (is_null($curr) || is_a($curr, LeftAndMain::class)) {
             return parent::urlForResource($relativePath);
         }
 


### PR DESCRIPTION
Tested & working. 

Added a default exclude rule for `startup.css`, the main styling of the OOTB 'Startup' theme. It contains `@import`s which break as the root file is prefixed and placed within _combinedfiles whereas all the referenced css files are not (the reason we added the exclusion mechanism originally).

(Happy to redo this without that if you'd prefer - but for an install against the default build, without it the entire front-end breaks.)